### PR TITLE
Leaderboard service sorting refactor using query

### DIFF
--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardController.java
@@ -17,6 +17,6 @@ public class LeaderboardController {
 
   @GetMapping
   public List<LeaderboardEntryDto> getLeaderboard() {
-    return service.getListOfAllLeaderboardEntriesAsDTO();
+    return service.getListOfDefaultLeaderboardEntriesAsDTO();
   }
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardRepository.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardRepository.java
@@ -1,8 +1,13 @@
 package com.gloot.springbootcodetest.leaderboard;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LeaderboardRepository extends JpaRepository<LeaderboardEntryEntity, UUID> {}
+public interface LeaderboardRepository extends JpaRepository<LeaderboardEntryEntity, UUID> {
+	
+	List<LeaderboardEntryEntity> findByLeaderboard_Name(String boardName);
+	
+}

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
@@ -2,14 +2,12 @@ package com.gloot.springbootcodetest.leaderboard;
 
 import static com.gloot.springbootcodetest.leaderboard.LeaderboardEntryMapper.mapToDto;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
@@ -19,31 +17,11 @@ public class LeaderboardService {
 	private final LeaderboardRepository repository;
 
 	public List<LeaderboardEntryDto> getListOfAllLeaderboardEntriesAsDTO() {
-		List<LeaderboardEntryEntity> allEntries = repository.findAll().stream().filter(e -> DEFAULT_BOARD.equals(e.getLeaderboard().getName())).collect(Collectors.toList());
-		Collections.sort(allEntries, new Comparator<LeaderboardEntryEntity>() {
-			public int compare(LeaderboardEntryEntity e1, LeaderboardEntryEntity e2) {
-				return e2.getScore() - e1.getScore();
-			}
-		});
-
-		LeaderboardEntryEntity[] allEntriesAsEntities = allEntries.toArray(new LeaderboardEntryEntity[] {});
-		LeaderboardEntryDto[] dtoObjects = new LeaderboardEntryDto[allEntriesAsEntities.length];
-
-		for (int i = allEntriesAsEntities.length - 1; i >= 0; i--) {
-			dtoObjects[i] = mapToDto(i + 1, allEntriesAsEntities[i]);
-		}
-
-		List<LeaderboardEntryDto> leaderboardEntryDtos = new ArrayList<>();
-		for (int j = dtoObjects.length - 1; j >= 0; j--) {
-			leaderboardEntryDtos.add(dtoObjects[j]);
-		}
-
-		Collections.sort(leaderboardEntryDtos, new Comparator<LeaderboardEntryDto>() {
-			public int compare(LeaderboardEntryDto e1, LeaderboardEntryDto e2) {
-				return e1.getPosition() - e2.getPosition();
-			}
-		});
-
-		return leaderboardEntryDtos;
+		var position = new AtomicInteger(1);
+		return repository.findByLeaderboard_Name(DEFAULT_BOARD).stream()
+			.sorted((e1,e2) -> e2.getScore() - e1.getScore())
+			.map(e -> mapToDto(position.getAndIncrement(), e))
+			.toList()
+			;
 	}
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
@@ -16,7 +16,7 @@ public class LeaderboardService {
 
 	private final LeaderboardRepository repository;
 
-	public List<LeaderboardEntryDto> getListOfAllLeaderboardEntriesAsDTO() {
+	public List<LeaderboardEntryDto> getListOfDefaultLeaderboardEntriesAsDTO() {
 		var position = new AtomicInteger(1);
 		return repository.findByLeaderboard_Name(DEFAULT_BOARD).stream()
 			.sorted((e1,e2) -> e2.getScore() - e1.getScore())

--- a/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardServiceTest.java
+++ b/src/test/java/com/gloot/springbootcodetest/leaderboard/LeaderboardServiceTest.java
@@ -25,7 +25,7 @@ public class LeaderboardServiceTest extends SpringBootComponentTest {
     repository.saveAll(entities);
 
     List<LeaderboardEntryDto> leaderboard = service
-        .getListOfAllLeaderboardEntriesAsDTO();
+        .getListOfDefaultLeaderboardEntriesAsDTO();
     assertEquals(entities.size(), leaderboard.size());
     // Verify ordering by score
     assertEqual(1, entities.get(1), leaderboard.get(0));


### PR DESCRIPTION
Update the implementation of `LeaderboardService` quering for the "DEFAULT" leaderboard instead using the computational filter. The sorting by score has been reimplemented using a single stream flow to improve code readibility. 

**List of Changes**

add findByLeaderboardsName to Leaderboard repository
update LeaderboardService with find default from repository and implementing sorting with a single java stream

**Motivation and Context**
Chore to improve perfomance and readibility

**How Has This Been Tested?**

unit test
