### PR TITLE
Add new endpoint to create or update user score in a leaderboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,11 @@
 			<artifactId>h2</artifactId>
 			<version>1.4.200</version>
 		</dependency>
-		<dependency>
-		    <groupId>org.springdoc</groupId>
-		    <artifactId>springdoc-openapi-core</artifactId>
-		    <version>1.1.49</version>
-		</dependency>
-	
+	   <dependency>
+	      <groupId>org.springdoc</groupId>
+	      <artifactId>springdoc-openapi-webmvc-core</artifactId>
+	      <version>1.6.11</version>
+	   </dependency>
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardController.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardController.java
@@ -5,10 +5,17 @@ import static com.gloot.springbootcodetest.Application.API_VERSION_1;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
 @RequestMapping(API_VERSION_1 + "/leaderboard")
@@ -17,18 +24,27 @@ public class LeaderboardController {
   private final LeaderboardService service;
 
   @GetMapping
+  @Operation(summary = "Get all the entries for the default leaderboard")
   public List<LeaderboardEntryDto> getLeaderboard() {
     return service.getListOfDefaultLeaderboardEntriesAsDTO();
   }
   
   @GetMapping(path = "/{name}")
+  @Operation(summary = "Get all the entries for the leaderboard with the input name")
   public List<LeaderboardEntryDto> getLeaderboard(@PathVariable String name) {
     return service.getListOfLeaderboardEntriesAsDTO(name);
   }
   
   @GetMapping(path = "/{name}/user/{nick}")
+  @Operation(summary = "Get the entry with the input nickname in the leaderboard with the input name")
   public LeaderboardEntryDto getLeaderboardForUser(@PathVariable String name, @PathVariable String nick) {
     return service.getLeaderboardEntryAsDTO(name, nick);
   }
   
+  @Operation(summary = "Create or update the entry with the input nick in the leaderboard with the input name")
+  @PutMapping(path = "/{name}/user/{nick}")
+  @ResponseStatus(HttpStatus.CREATED)
+  public void putLeaderboardForUser(@PathVariable String name, @PathVariable String nick, @RequestBody LeaderboardNewEntryDto entry) {
+    service.addLeaderboardEntry(name, nick, entry);
+  }
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryDto.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryDto.java
@@ -5,7 +5,7 @@ import lombok.Value;
 
 @Builder
 @Value
-public class LeaderboardEntryDto {
+public class LeaderboardEntryDto implements WithNick {
   int position;
   String nick;
   int score;

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryEntity.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardEntryEntity.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class LeaderboardEntryEntity {
+public class LeaderboardEntryEntity implements WithNick {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private UUID uuid;

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardNewEntryDto.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardNewEntryDto.java
@@ -1,0 +1,14 @@
+package com.gloot.springbootcodetest.leaderboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardNewEntryDto {
+  int score;
+}

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/LeaderboardService.java
@@ -4,12 +4,16 @@ import static com.gloot.springbootcodetest.leaderboard.LeaderboardEntryMapper.ma
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.gloot.springbootcodetest.errors.EntityNotFoundException;
+import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
 import com.gloot.springbootcodetest.leaderboards.LeaderboardsRepository;
 
 import lombok.AllArgsConstructor;
@@ -19,14 +23,21 @@ import lombok.AllArgsConstructor;
 public class LeaderboardService {
 	private static final String DEFAULT_BOARD = "DEFAULT";
 	private static final Comparator<LeaderboardEntryEntity> HIGHER_SCORE_FIRST = (e1, e2) -> e2.getScore()- e1.getScore();
-
+	
 	private final LeaderboardRepository repository;
 	private final LeaderboardsRepository leaderboardsRepo;
 
+	/**Retrieve all the entries of the default leaderboard (having the name {@value #DEFAULT_BOARD})
+	 * @return a list of entries
+	 */
 	public List<LeaderboardEntryDto> getListOfDefaultLeaderboardEntriesAsDTO() {
 		return getListOfLeaderboardEntriesAsDTO(DEFAULT_BOARD);
 	}
 
+	/**Retrieve all the entries of the leaderboard having the input name. Will throw an {@link EntityNotFoundException} if the leaderboard do not exist.
+	 * @param name the leaderboard name
+	 * @return a list of entries
+	 */
 	public List<LeaderboardEntryDto> getListOfLeaderboardEntriesAsDTO(String name) {
 		var position = new AtomicInteger(1);
 		var leaderboardAsDtos = repository.findByLeaderboard_Name(name)
@@ -40,13 +51,42 @@ public class LeaderboardService {
 		return leaderboardAsDtos;
 	}
 
+	/**Retrieve the leaderboard entry having the input nick in the input leaderboard name. Will throw an {@link EntityNotFoundException} if the leaderboard do not exist or do not contains an entry for the input nickname.
+	 * @param name a leaderboard name
+	 * @param nick a nickname
+	 * @return an entry
+	 */
 	public LeaderboardEntryDto getLeaderboardEntryAsDTO(String name, String nick) {
-		System.out.println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAA: "+nick);
 		return getListOfLeaderboardEntriesAsDTO(name).stream()
-				.map(e -> {System.out.println("BBBBBB:"+e.getNick()+" "+StringUtils.equals(e.getNick(), nick)); return e;})
-				.filter(e -> StringUtils.equals(e.getNick(), nick))
+				.filter(getHaveTheSameNickPredicate(nick))
 				.findAny()
 				.orElseThrow(() -> new EntityNotFoundException("Missing user with the requested nickname"));
 	}
+	
+	/**Add or Update in the leaderboard (having the input name) the entry having the input nickname with the input data. If the leaderboard do not exists, it will be created.
+	 * @param name a leaderboard name
+	 * @param nick a nickname
+	 * @param entryToAdd the data to add/update
+	 */
+	@Transactional
+	public void addLeaderboardEntry(String name, String nick, LeaderboardNewEntryDto entryToAdd) {
+		leaderboardsRepo.findByName(name)
+			.or(() -> Optional.of(leaderboardsRepo.save(new LeaderboardsEntryEntity(name))))
+			.flatMap(board -> 
+				repository.findByLeaderboard_Name(name).stream()
+					.filter(getHaveTheSameNickPredicate(nick))
+					.findAny()
+					.map(user -> user.toBuilder().score(entryToAdd.getScore()).build())
+				.or(() -> Optional.of(new LeaderboardEntryEntity(nick, entryToAdd.getScore(), board)))
+				.map(repository::save)
+			)
+			.orElseThrow(() -> new IllegalStateException("Something go wrong! We could not put together the failure cause, please contact our backoffice."))
+			;
+	}
 
+	private static Predicate<WithNick> getHaveTheSameNickPredicate(String nick) {
+		return (e) ->  StringUtils.equals(e.getNick(), nick);
+	}
+	
+	
 }

--- a/src/main/java/com/gloot/springbootcodetest/leaderboard/WithNick.java
+++ b/src/main/java/com/gloot/springbootcodetest/leaderboard/WithNick.java
@@ -1,0 +1,7 @@
+package com.gloot.springbootcodetest.leaderboard;
+
+public interface WithNick {
+
+	String getNick();
+	
+}

--- a/src/main/resources/db/migration/V3__add_multi_boards_support.sql
+++ b/src/main/resources/db/migration/V3__add_multi_boards_support.sql
@@ -9,4 +9,6 @@ INSERT INTO leaderboards(name) VALUES ('DEFAULT');
 
 UPDATE leaderboard SET board_id = (SELECT uuid FROM leaderboards WHERE name = 'DEFAULT');
 
-alter table leaderboard alter column board_id UUID NOT NULL;
+ALTER TABLE leaderboard ALTER COLUMN board_id UUID NOT NULL;
+
+ALTER TABLE leaderboard ADD UNIQUE(board_id, nick);

--- a/src/test/java/com/gloot/springbootcodetest/leaderboard/DummyUtil.java
+++ b/src/test/java/com/gloot/springbootcodetest/leaderboard/DummyUtil.java
@@ -3,10 +3,20 @@ package com.gloot.springbootcodetest.leaderboard;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gloot.springbootcodetest.leaderboards.LeaderboardsEntryEntity;
 import com.gloot.springbootcodetest.leaderboards.LeaderboardsRepository;
 
 public final class DummyUtil {
+	
+	public static final String A_LEADERBOARD_NAME = "WORLD";
+	public static final String A_NICK = "BOB";
+	public static final int A_SCORE = 1000;
+	
+	public static <T> String objectAsJson(T input) throws JsonProcessingException {
+		return new ObjectMapper().writeValueAsString(input);
+	}
 	
 	public static List<LeaderboardEntryEntity> initLeaderboardWithNUsers(LeaderboardRepository leaderboardRepo, LeaderboardsRepository leaderboardsRepo, String name, int size) {
 		LeaderboardsEntryEntity board = leaderboardsRepo.findByName(name)


### PR DESCRIPTION
Add a new endpoint to create or update the user score. This endpoint will also create the leaderboard, if missing.

**List of Changes**

add PUT operation to LeaderboardController
add add operation to LeaderboardService
add new constraint on 'leaderboard' entity
add springdoc-openapi to genarate the openapi documentation 
fix test

**Motivation and Context**

Allow API user to create and update score for a specific nickname, in a specific leaderboard.

**How Has This Been Tested?**

unit test